### PR TITLE
Made NamedAction public

### DIFF
--- a/aws2scala-core/src/main/scala/com/monsanto/arch/awsutil/auth/policy/Action.scala
+++ b/aws2scala-core/src/main/scala/com/monsanto/arch/awsutil/auth/policy/Action.scala
@@ -48,5 +48,5 @@ object Action {
   }
 
   /** Used to generate `Action` instances when no matching action has been registered. */
-  private[awsutil] case class NamedAction(override val name: String) extends Action(name)
+  case class NamedAction(override val name: String) extends Action(name)
 }

--- a/aws2scala-kms-tests/src/test/scala/com/monsanto/arch/awsutil/kms/DefaultKMSClientSpec.scala
+++ b/aws2scala-kms-tests/src/test/scala/com/monsanto/arch/awsutil/kms/DefaultKMSClientSpec.scala
@@ -28,6 +28,7 @@ class DefaultKMSClientSpec extends FreeSpec with Materialised with MockFactory w
   case class Fixture(awsClient: AWSKMSAsync, asyncClient: AsyncKMSClient, streamingClient: StreamingKMSClient)
 
   private def withFixture(test: Fixture ⇒ Any): Unit = {
+    KMS.init()
     val aws = mock[AWSKMSAsync]("aws")
     val streaming = new DefaultStreamingKMSClient(aws)
     val async = new DefaultAsyncKMSClient(streaming)


### PR DESCRIPTION
This is for two reasons:

- We just haven't yet modeled all of the many actions out there as type-safe classes.
- It wouldn't necessarily make sense to try to do so, especially for modules that we haven't yet modeled in aws2scala.  For example, we haven't modeled SES, so until we do, where would we put such a model for the actions?  The policy functionality in the IAM module is for policies, and shouldn't be limited to policies that touch things we've modeled.